### PR TITLE
Fix inline code blocks not being monospace

### DIFF
--- a/base.css
+++ b/base.css
@@ -739,7 +739,7 @@ mark:not(pre)>code {
 .white-theme :not(pre)>code {
     border-radius: var(--cl-border-radius);
     font-size: 90%;
-    font-family: "iA Writer Duo S", "SF Mono";
+    font-family: "iA Writer Duo S", "SF Mono", "MonoLisa", "Fira Code", "Monaco", "Menlo", "Consolas", "COURIER NEW", monospace;
     padding: 1px 3px !important;
     /*background: transparent;*/
     color: var(--color-secondary);
@@ -751,7 +751,7 @@ mark:not(pre)>code {
 .dark-theme :not(pre)>code {
     border-radius: var(--cl-border-radius);
     font-size: 85%;
-    font-family: "iA Writer Duo S", "SF Mono";
+    font-family: "iA Writer Duo S", "SF Mono", "MonoLisa", "Fira Code", "Monaco", "Menlo", "Consolas", "COURIER NEW", monospace;
     padding: 1px 3px !important;
     /*background: transparent;*/
     color: var(--color-secondary);


### PR DESCRIPTION
You set font-family to some fonts I see for the first time in my life that are obviously absent from my system.

Add original families from logseq to fall back on when this happens, ending with a generic _monospace_.